### PR TITLE
Use visible width for column number on status line

### DIFF
--- a/render.go
+++ b/render.go
@@ -155,7 +155,7 @@ func editorUpdateStatus(buf *EditorBuffer) string {
 		dc = '*'
 	}
 	return fmt.Sprintf("-%c %s - (%s) %d:%d", dc, fn, buf.MajorMode,
-		buf.cy+1, buf.cx)
+		buf.cy+1, buf.Rows[buf.cy].cxToRx(buf.cx))
 }
 
 func GetScreenSize() (int, int) {


### PR DESCRIPTION
This is a minor PR to update the status line to display the visible width of the characters before the cursor instead of the number of bytes before the cursor.  With this change, the Gomacs status line column number is the same as the GNU Emacs status line column number.