### PR TITLE
Implement tab stops

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/zhemao/glisp/interpreter"
+	glisp "github.com/zhemao/glisp/interpreter"
 )
 
 type CommandList struct {
@@ -278,7 +278,7 @@ func LoadDefaultCommands() {
 		func(env *glisp.Glisp) { editorUndoAction() }, false})
 	DefineCommand(&CommandFunc{"indent",
 		func(env *glisp.Glisp) {
-			editorInsertStr(getTabString())
+			editorIndent()
 		}, false})
 	DefineCommand(&CommandFunc{"other-window",
 		func(env *glisp.Glisp) { switchWindow() }, false})

--- a/render.go
+++ b/render.go
@@ -17,6 +17,10 @@ func init() {
 	redrawLock = &sync.Mutex{}
 }
 
+func nextTabStop(rx int) int {
+	return Global.Tabsize - rx%Global.Tabsize
+}
+
 func (row *EditorRow) cxToRx(cx int) int {
 	rx := 0
 	for i, rv := range row.Data {
@@ -24,7 +28,7 @@ func (row *EditorRow) cxToRx(cx int) int {
 			break
 		}
 		if rv == '\t' {
-			rx += Global.Tabsize
+			rx += nextTabStop(rx)
 		} else {
 			rx += termutil.Runewidth(rv)
 		}
@@ -41,7 +45,7 @@ func editorRowRxToCx(row *EditorRow, rx int) int {
 	var cx int
 	for cx = 0; cx < row.Size; cx++ {
 		if row.Data[cx] == '\t' {
-			cur_rx += Global.Tabsize
+			cur_rx += nextTabStop(cur_rx)
 		} else {
 			cur_rx++
 		}


### PR DESCRIPTION
Rather than displaying `'\t'` as `Global.Tabsize` spaces, display it as spaces up to the next tab stop, where tab stops occur every `Global.Tabsize` screen columns.  The old method and the new method differ only for tabs which aren't on a tab stop boundary.

When `Global.SoftTab` is enabled, have TAB insert the number of spaces to reach the next tab stop: this can be smaller number
than `Global.Tabsize`, particularly when using TAB for the sake of alignment rather than indentation.