### PR TITLE
Mouse fix for UTF-8 characters

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -234,11 +234,11 @@ func editorFindCallback(query string, key string) {
 			current = 0
 		}
 		row := Global.CurrentB.Rows[current]
-		match := strings.Index(row.Render, query)
+		match := strings.Index(row.Data, query)
 		if match > -1 {
 			last_match = current
 			Global.CurrentB.cy = current
-			Global.CurrentB.cx = editorRowRxToCx(row, match)
+			Global.CurrentB.cx = match
 			Global.CurrentB.prefcx = Global.CurrentB.cx
 			Global.CurrentB.rowoff = Global.CurrentB.NumRows
 			Global.CurrentB.MarkX = Global.CurrentB.cx + ql
@@ -336,13 +336,13 @@ func doReplaceString() {
 	ql := len(orig)
 	nl := len(replace)
 	for cy, row := range Global.CurrentB.Rows {
-		match := strings.LastIndex(row.Render, orig)
+		match := strings.LastIndex(row.Data, orig)
 		if match != -1 {
-			count := strings.Count(row.Render, orig)
+			count := strings.Count(row.Data, orig)
 			matches += count
 			lines++
 			Global.CurrentB.cy = cy
-			Global.CurrentB.cx = editorRowRxToCx(row, match+ql-(count*(ql-nl)))
+			Global.CurrentB.cx = match + ql - (count * (ql - nl))
 			Global.CurrentB.prefcx = Global.CurrentB.cx
 			Global.CurrentB.rowoff = Global.CurrentB.NumRows
 			Global.CurrentB.Dirty = true
@@ -443,7 +443,7 @@ func doReplaceRegexp() {
 			matches += count
 			lines++
 			Global.CurrentB.cy = cy
-			Global.CurrentB.cx = editorRowRxToCx(row, row.Size)
+			Global.CurrentB.cx = row.Size
 			Global.CurrentB.prefcx = Global.CurrentB.cx
 			Global.CurrentB.rowoff = Global.CurrentB.NumRows
 			Global.CurrentB.Dirty = true

--- a/render.go
+++ b/render.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strconv"
 	"sync"
+	"unicode/utf8"
 
 	termutil "github.com/japanoise/termbox-util"
 	"github.com/mattn/go-runewidth"
@@ -39,15 +40,17 @@ func editorRowCxToRx(row *EditorRow) int {
 func editorRowRxToCx(row *EditorRow, rx int) int {
 	cur_rx := 0
 	var cx int
-	for cx = 0; cx < row.Size; cx++ {
-		if row.Data[cx] == '\t' {
+	for cx = 0; cx < row.Size; {
+		rv, len := utf8.DecodeRuneInString(row.Data[cx:])
+		if rv == '\t' {
 			cur_rx += Global.Tabsize
 		} else {
-			cur_rx++
+			cur_rx += termutil.Runewidth(rv)
 		}
 		if cur_rx > rx {
 			return cx
 		}
+		cx += len
 	}
 	return cx
 }


### PR DESCRIPTION
If you open [UTF-8-demo.txt](https://raw.githubusercontent.com/japanoise/gomacs/cd15ac8db97007ac062dac815b7ac7c5398a6ba5/UTF-8-demo.txt) in `gomacs` and start clicking around with the mouse, you will note that it doesn't handle multi-byte characters correctly.  The cell number that was clicked is—except for tab characters—treated like a byte offset when positioning the cursor.

This problem can be fixed by updating `editorRowRxToCx` to be aware of the length and display width of the characters in the row.

This change to `editorRowRxToCx` would break the search/replace code in nav.go that was using it.  I think this can be solved by eliminating those calls:

* `editorFindCallback` and `doReplaceString` had an index into `EditorRow.Render`.  While that string has tabs replaced by spaces, it's not a _true_ "rx" value because it doesn't account for double wide characters.  Thus, passing those indexes into the updated `editorRowRxToCx` would yield the wrong result.  It looks to me that those functions can just use indices into `EditorRow.Data` instead, eliminating the need to use `editorRowRxToCx` at all.  This also has the beneficial effect that searching for spaces won't match tab characters (which wasn't being highlighted correctly and so presumably wasn't intended behavior).
* `doReplaceRegexp` doesn't look like it needs to use `editorRowRxToCx`.  It's passing in `EditorRow.Size` (a byte value) and storing the result in `EditorBuffer.cx` (also a byte value).

Note: If you accept https://github.com/japanoise/gomacs/pull/27, be aware that this PR has a trivial merge conflict with it.  Both PRs modify `editorRowRxToCx`.  https://github.com/japanoise/gomacs/pull/27 only changes one line in that function, so the conflict should be easy to resolve.