### PR TITLE
Allow tab characters for search/find/replace

### DIFF
--- a/input.go
+++ b/input.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"time"
 	"unicode/utf8"
 
-	"github.com/japanoise/termbox-util"
+	termutil "github.com/japanoise/termbox-util"
 	"github.com/nsf/termbox-go"
 )
 
@@ -265,6 +266,15 @@ func EditDynamicWithCallback(defval, prompt string, refresh func(int, int), call
 			if buflen > 0 && bufpos < buflen {
 				bufpos = forwardWordIndex(buffer, bufpos)
 				cursor = termutil.RunewidthStr(buffer[:bufpos])
+			}
+		case "C-i", "TAB":
+			// Allow tabs to be input only for commands which have no need for
+			// tab completion.
+			if prompt == "Search" || prompt == "Find" || prompt == "Find regexp" ||
+				strings.HasPrefix(prompt, "Replace ") && strings.HasSuffix(prompt, " with") {
+				buffer = buffer[:bufpos] + "\t" + buffer[bufpos:]
+				bufpos++
+				cursor++
 			}
 		default:
 			if utf8.RuneCountInString(key) == 1 {

--- a/input.go
+++ b/input.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -270,8 +269,7 @@ func EditDynamicWithCallback(defval, prompt string, refresh func(int, int), call
 		case "C-i", "TAB":
 			// Allow tabs to be input only for commands which have no need for
 			// tab completion.
-			if prompt == "Search" || prompt == "Find" || prompt == "Find regexp" ||
-				strings.HasPrefix(prompt, "Replace ") && strings.HasSuffix(prompt, " with") {
+			if isSearchPrompt(prompt) {
 				buffer = buffer[:bufpos] + "\t" + buffer[bufpos:]
 				bufpos++
 				cursor++

--- a/nav.go
+++ b/nav.go
@@ -196,6 +196,22 @@ func MoveCursorForthPage() {
 	}
 }
 
+const (
+	PromptSearch        = "Search"
+	PromptFind          = "Find"
+	PromptFindRegexp    = PromptFind + " regexp"
+	PromptReplacePrefix = "Replace "
+	PromptReplaceSuffix = " with"
+)
+
+func isSearchPrompt(prompt string) bool {
+	switch prompt {
+	case PromptSearch, PromptFind, PromptFindRegexp:
+		return true
+	}
+	return strings.HasPrefix(prompt, PromptReplacePrefix) && strings.HasSuffix(prompt, PromptReplaceSuffix)
+}
+
 // HACK: Go does not have static variables, so these have to go in global state.
 var last_match int = -1
 var direction int = 1
@@ -255,7 +271,7 @@ func editorFind() {
 	saved_cy := Global.CurrentB.cy
 	saved_ro := Global.CurrentB.rowoff
 
-	query := editorPrompt("Search", editorFindCallback)
+	query := editorPrompt(PromptSearch, editorFindCallback)
 
 	if query == "" {
 		//Search cancelled, go back to where we were
@@ -268,13 +284,13 @@ func editorFind() {
 }
 
 func doQueryReplace() {
-	orig := editorPrompt("Find", nil)
+	orig := editorPrompt(PromptFind, nil)
 	if orig == "" {
 		Global.Input = "Can't query-replace with an empty query"
 		return
 	}
 	defer func() { Global.CurrentB.regionActive = false }()
-	replace := editorPrompt("Replace "+orig+" with", nil)
+	replace := editorPrompt(PromptReplacePrefix+orig+PromptReplaceSuffix, nil)
 	all := false
 	ql := len(orig)
 	rlen := len(replace)
@@ -325,12 +341,12 @@ func doQueryReplace() {
 }
 
 func doReplaceString() {
-	orig := editorPrompt("Find", nil)
+	orig := editorPrompt(PromptFind, nil)
 	if orig == "" {
 		Global.Input = "Can't string-replace with an empty query"
 		return
 	}
-	replace := editorPrompt("Replace "+orig+" with", nil)
+	replace := editorPrompt(PromptReplacePrefix+orig+PromptReplaceSuffix, nil)
 	matches := 0
 	lines := 0
 	ql := len(orig)
@@ -362,7 +378,7 @@ func doReplaceString() {
 }
 
 func doQueryReplaceRegexp() {
-	orig := editorPrompt("Find regexp", nil)
+	orig := editorPrompt(PromptFindRegexp, nil)
 	if orig == "" {
 		Global.Input = "Can't query-replace-regexp with an empty query"
 		return
@@ -373,7 +389,7 @@ func doQueryReplaceRegexp() {
 		Global.Input = "Couldn't compile regexp " + orig + ": " + err.Error()
 		return
 	}
-	replace := editorPrompt("Replace "+orig+" with", nil)
+	replace := editorPrompt(PromptReplacePrefix+orig+PromptReplaceSuffix, nil)
 	all := false
 	for cy, row := range Global.CurrentB.Rows {
 		match := pattern.FindStringIndex(row.Data)
@@ -423,7 +439,7 @@ func doQueryReplaceRegexp() {
 }
 
 func doReplaceRegexp() {
-	orig := editorPrompt("Find regexp", nil)
+	orig := editorPrompt(PromptFindRegexp, nil)
 	if orig == "" {
 		Global.Input = "Can't replace-regexp with an empty query"
 		return


### PR DESCRIPTION
For your consideration, the simple way to allow inputting tab characters for search and find/replace: hard-code special cases in `EditDynamicWithCallback`.

Not particularly elegant, but the alternatives I could think of weren't better.  One alternative would be to pass a `bool` into `editorPrompt` indicating whether inputting tabs should be allowed: but that parameter would also need to be added to `PromptWithCallback`, `DynamicPromptWithCallback`, and `EditDynamicWithCallback`... which seems messy.  Another alternative would be for the search and find/replace functions to handle tab insertions in a callback, but that would only work if the callback was provided with the buffer position (`bufpos` in `EditDynamicWithCallback`), which seems like a big change for such a minor feature...

If you don't want to do it this way, feel free to close the PR without merging it.