### PR TITLE
Clean up imports

### DIFF
--- a/dired.go
+++ b/dired.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/zhemao/glisp/interpreter"
+	glisp "github.com/zhemao/glisp/interpreter"
 )
 
 func DiredMode(env *glisp.Glisp) {

--- a/input.go
+++ b/input.go
@@ -5,7 +5,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/japanoise/termbox-util"
+	termutil "github.com/japanoise/termbox-util"
 	"github.com/nsf/termbox-go"
 )
 

--- a/lisp.go
+++ b/lisp.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 
 	"github.com/mitchellh/go-homedir"
-	"github.com/zhemao/glisp/interpreter"
+	glisp "github.com/zhemao/glisp/interpreter"
 )
 
 func lispGetKey(env *glisp.Glisp, name string, args []glisp.Sexp) (glisp.Sexp, error) {

--- a/macro.go
+++ b/macro.go
@@ -1,8 +1,6 @@
 package main
 
-import (
-	"github.com/zhemao/glisp/interpreter"
-)
+import glisp "github.com/zhemao/glisp/interpreter"
 
 type EditorAction struct {
 	HasUniversal bool

--- a/modes.go
+++ b/modes.go
@@ -1,8 +1,6 @@
 package main
 
-import (
-	"github.com/zhemao/glisp/interpreter"
-)
+import glisp "github.com/zhemao/glisp/interpreter"
 
 // Minor Modes
 type ModeList map[string]bool

--- a/region.go
+++ b/region.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/japanoise/termbox-util"
+	termutil "github.com/japanoise/termbox-util"
 )
 
 type Region struct {

--- a/registers.go
+++ b/registers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/zhemao/glisp/interpreter"
+	glisp "github.com/zhemao/glisp/interpreter"
 )
 
 type RegisterType uint8

--- a/shell.go
+++ b/shell.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/kballard/go-shellquote"
-	"github.com/zhemao/glisp/interpreter"
+	glisp "github.com/zhemao/glisp/interpreter"
 )
 
 func shellCmd(com string, args []string) (string, error) {

--- a/syntax.go
+++ b/syntax.go
@@ -3,9 +3,9 @@ package main
 import (
 	"strings"
 
-	"github.com/japanoise/termbox-util"
+	termutil "github.com/japanoise/termbox-util"
 	"github.com/nsf/termbox-go"
-	"github.com/zhemao/glisp/interpreter"
+	glisp "github.com/zhemao/glisp/interpreter"
 	"github.com/zyedidia/highlight"
 )
 

--- a/undo.go
+++ b/undo.go
@@ -3,7 +3,7 @@ package main
 import (
 	"strings"
 
-	"github.com/zhemao/glisp/interpreter"
+	glisp "github.com/zhemao/glisp/interpreter"
 )
 
 type EditorUndo struct {

--- a/window.go
+++ b/window.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	termbox "github.com/nsf/termbox-go"
-	"github.com/zhemao/glisp/interpreter"
+	glisp "github.com/zhemao/glisp/interpreter"
 )
 
 type winTree struct {

--- a/word.go
+++ b/word.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/japanoise/termbox-util"
+	termutil "github.com/japanoise/termbox-util"
 	glisp "github.com/zhemao/glisp/interpreter"
 )
 


### PR DESCRIPTION
Done with the `lsp-organize-imports` function from the `lsp-mode` package for GNU Emacs, with `gopls` as the LSP server.

As [requested](https://github.com/japanoise/gomacs/pull/31#discussion_r808289249), so that future PRs won't be cluttered with automatic import clean ups.