### PR TITLE
Make auto-fill-mode less aggressive

### DIFF
--- a/region.go
+++ b/region.go
@@ -469,10 +469,7 @@ func doFillRegion() {
 }
 
 func insertSpaceMaybeFill() {
-	if Global.CurrentB.hasMode("auto-fill-mode") &&
-		Global.CurrentB.Rows[Global.CurrentB.cy].RenderSize >= Global.Fillcolumn {
-		doFillParagraph()
-	}
+	doAutoFillParagraph()
 	editorInsertStr(" ")
 }
 


### PR DESCRIPTION
Change `auto-fill-mode` so that it only fills the current line when space is pressed and point is beyond the fill column.  This is the behavior used by the GNU Emacs auto-fill-mode.

The previous behavior—filling the whole paragraph whenever space is pressed and the line length is beyond the fill column—is available with `aggressive-fill-mode`.

Fixes https://github.com/japanoise/gomacs/issues/30