### PR TITLE
Force forward progress for query-replace-regexp

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -417,6 +417,15 @@ func doQueryReplaceRegexp() {
 				prestring = prestring + matchstring[:match[1]]
 				matchstring = matchstring[match[1]:]
 			}
+			if matchlen == 0 {
+				if len(matchstring) == 0 {
+					break
+				}
+				// Force forward progress
+				_, rl := utf8.DecodeRuneInString(matchstring)
+				prestring += matchstring[:rl]
+				matchstring = matchstring[rl:]
+			}
 			match = pattern.FindStringIndex(matchstring)
 		}
 	}


### PR DESCRIPTION
One way that https://github.com/japanoise/gomacs/issues/36 could be fixed, which has the end result that Gomacs and GNU Emacs have the same behavior in this situation.