### PR TITLE
Fix cursor position with empty lines

### DIFF
--- a/render.go
+++ b/render.go
@@ -130,7 +130,7 @@ func editorDrawRowsFocused(startx, starty, sx, sy int, buf *EditorBuffer, gutsiz
 				}
 			}
 			if filerow == buf.cy {
-				termbox.SetCursor(0, y)
+				termbox.SetCursor(startx+gutsize, y)
 			}
 			if row.coloff < row.RenderSize {
 				ts, off := trimString(row.Render, row.coloff)


### PR DESCRIPTION
I noticed that the cursor wasn't drawn correctly when it was on an empty line and there was something to the left of the cursor, such as a gutter (for `line-number-mode`) or another window.  For example:

```sh
echo -e "a\n\n\n\nb" > el.txt
gomacs el.txt
```

If `line-number-mode` is enabled when the cursor is on one of the empty lines between "a" and "b", the cursor will be drawn to the left of the gutter, on the line number.

Or if the window is split with `C-x 3` and you switch to the right window with `C-x o`, then when the cursor is on one of the empty lines between "a" and "b" in the right window, the cursor will be drawn in the left window.

In `editorDrawRowsFocused`, when the cursor is on an empty line, the `row.RenderSize` will be zero, so `row.PrintWCursor` won't be called.  The cursor will be left at its previous position, `(0,y)`.  However, an x-coordinate of 0 is only correct for the leftmost window and only if there is no gutter.  This can be fixed by putting the cursor at the start of the line, accounting for leftward windows and the gutter: an x-coordinate of `startx+gutsize` rather than `0`.